### PR TITLE
Update params and install poetry release

### DIFF
--- a/poetry/Dockerfile
+++ b/poetry/Dockerfile
@@ -1,19 +1,17 @@
 FROM python:3.10 as base
 
-COPY pyproject.toml poetry.lock .
-RUN pip install git+https://github.com/adriangb/poetry.git@skip-path-dep-install \
-    && pip uninstall -y poetry-core \
-    && pip install -U git+https://github.com/python-poetry/poetry-core.git@main \
-    && poetry config virtualenvs.create false
+COPY pyproject.toml poetry.lock ./
+RUN pip install poetry && \
+    poetry config virtualenvs.create false
 
 FROM base as app
-RUN poetry install --only app --no-path
+RUN poetry install --only app --no-directory
 COPY workspaces/ workspaces/
 RUN poetry install --only app
 CMD ["poetry", "run", "python", "workspaces/app/src/namespace/app/main.py"]
 
 FROM base as cli
-RUN poetry install --only cli --no-path
+RUN poetry install --only cli --no-directory
 COPY workspaces/ workspaces/
 RUN poetry install --only cli
 CMD ["poetry", "run", "python", "workspaces/cli/src/namespace/cli/main.py"]


### PR DESCRIPTION
Now that https://github.com/python-poetry/poetry/pull/6845 is merged, this is to install poetry from normal release instead of from the branch and to use the correct params.